### PR TITLE
feat(Table):add fields to manage custom pagination

### DIFF
--- a/library/src/datatable/Table/Table.tsx
+++ b/library/src/datatable/Table/Table.tsx
@@ -71,13 +71,12 @@ const Table = forwardRef(function Table(props: TableProps, ref) {
     columns: lcolumns,
     data: ldata /*, TableBody, TableCell, TableRow*/,
     options,
+    paginationProps,
     localization,
   } = props;
 
   const columns = useMemo(() => lcolumns, []);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const data = useMemo(() => ldata, []);
-
   const {
     //TABLE
     //getTableProps,
@@ -124,7 +123,9 @@ const Table = forwardRef(function Table(props: TableProps, ref) {
       columns,
       data: ldata,
       initialState: {
-        pagination: { pageSize: options?.pageSize || 10 },
+        pagination: {
+          pageSize: options?.pageSize ?? paginationProps?.limit ?? 10,
+        },
       },
 
       /*globalFilterFn: (row, columnId, filterValue) => {
@@ -489,11 +490,12 @@ const Table = forwardRef(function Table(props: TableProps, ref) {
           </nav>
         ) : (
           options?.paginationComponente &&
-          React.cloneElement(options.paginationComponente as any, {
-            pagesTotal: options?.pagesTotal,
-            countTotal: options?.countTotal,
-            page: pageIndex,
-            limit: pageSize,
+          React.cloneElement(options.paginationComponente, {
+            ...paginationProps, // Pasa todas las propiedades definidas
+            pagesTotal: paginationProps?.pagesTotal,
+            countTotal: paginationProps?.countTotal,
+            page: paginationProps?.page,
+            limit: paginationProps?.limit,
             onPageChange: handlePageChange,
             onPageSizeChange: handlePageSizeChange,
           })

--- a/library/src/datatable/Table/Table.types.ts
+++ b/library/src/datatable/Table/Table.types.ts
@@ -45,13 +45,12 @@ export interface Options {
   grouping?: boolean;
   overflowY?: 'visible' | 'hidden' | 'scroll' | 'auto' | 'initial' | 'inherit';
   pageSize?: number;
-  pagesTotal?: number;
-  countTotal?: number;
+  pageIndex?: number;
   pageSizeOptions?: number[];
   usePaginationDefault?: boolean;
   useFilterGlobalDefault?: boolean;
   filterGlobalComponente?: React.ReactNode;
-  paginationComponente?: React.ReactNode;
+  paginationComponente?: React.ReactElement<PaginationCustomizedProps>;
   paginationType?: 'normal' | 'stepped';
   rowStyle?:
     | React.CSSProperties
@@ -141,6 +140,14 @@ export interface Action {
   hidden?: boolean;
 }
 
+export interface PaginationCustomizedProps<T = {}> {
+  pagesTotal?: number;
+  countTotal?: number;
+  page?: number;
+  limit?: number;
+  [key: string]: any;
+}
+
 //export interface TableProps<D extends React.ElementType = 'table'> {
 export interface TableProps {
   className?: string;
@@ -154,6 +161,7 @@ export interface TableProps {
   data: object[];
   localization?: Localization;
   options?: Options;
+  paginationProps?: PaginationCustomizedProps;
   actions?: Action[];
   //action
 


### PR DESCRIPTION
Objetivo: 
Agregar mejora en la definición de campos para la paginación personalizada. 
Actualmente se pueden definir infinitos campos necesarios para la paginación en **paginationProps**. 

Ejemplo de esto:
```typescript
   <Table
               ....
                options={{
               ........
                  paginationComponente: <Paginate />,
                }}
                paginationProps={{
                  limit: Number(limit) || 0,
                  page: Number(page) || 0,
                  pagesTotal: 5,
                  countTotal: Number(limit) || 0,
                }}
``` 

- [X] Bug fix (non-breaking change)
- [X] Nueva funcionalidad (non-breaking change)
- [ ] Breaking change (fix o nueva funcionalidad con un breaking change)
- [ ] Este cambio requiere una actualización de la documentación
- [ ] Este cambio es una refactorización

## Variables de Entorno

Indica aquí las variables de entorno a agregar (no incluir el valor de las variables de entorno, sólo el nombre).
## Migrations

Agregar los migrations necesarios para este PR.

# Pruebas

Describe los test que se realizaron para comprobar estos cambios. Provee instrucciones y detalles para poder reproducirlo.

- [] Test A
- [] Test B
  ...

# Mejoras

Describe las mejoras que hiciste al código ya existente si aplica.

# Checklist

- [x] Mi código sigue los estándares de código de este proyecto.
- [x] He revisado mi propio código y comprobé que funciona.
- [x] Revisé donde se usan mis cambios y no afectan negativamente el resto del proyecto.
- [X] He agregado los comentarios necesarios en el código en las áreas que amerita.
- [X] He actualizado la documentación correspondiente.
- [x] Mis cambios no generan errores o warnings.
- [ ] He agregado tests para probar que mi arreglo o funcionalidad funciona correctamente.
- [x] He probado los casos borde.
- [ ] Los tests anteriores y nuevos pasan.
- [x] No existen problemas de merge con la rama.
- [x] Manejo correctamente los errores.
- [x] Declaro que probé la funcionalidad de este PR en su totalidad y que funciona de acuerdo a lo esperado.
